### PR TITLE
OCP 4.11 Support

### DIFF
--- a/.github/linters/.gitleaks.toml
+++ b/.github/linters/.gitleaks.toml
@@ -2,7 +2,7 @@
 # As of v4, gitleaks only matches against filename, not path in the
 # files directive.  Leaving content for backwards compatibility.
 files = [
-  "ansible/plugins/modules/*.py",
-  "ansible/tests/unit/test_*.py",
-  "ansible/tests/unit/*.yaml",
+  "common/ansible/plugins/modules/*.py",
+  "common/ansible/tests/unit/test_*.py",
+  "common/ansible/tests/unit/v1/*.yaml",
 ]

--- a/charts/hub/bobbycar-core-apps/templates/car-simulator-dc.yaml
+++ b/charts/hub/bobbycar-core-apps/templates/car-simulator-dc.yaml
@@ -35,7 +35,7 @@ spec:
             defaultMode: 420
       containers:
       - name: {{ .Values.carSimulator.name }}
-        image: quay.io/bobbycar/car-simulator:1.1.0
+        image: quay.io/bobbycar/car-simulator:1.1.1
         imagePullPolicy: Always
         volumeMounts:
             - name: config

--- a/charts/hub/bobbycar-core-infra/templates/kafka-cr.yaml
+++ b/charts/hub/bobbycar-core-infra/templates/kafka-cr.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.1.0
     replicas: {{ .Values.kafka.cluster.brokerReplicas }}
     listeners:
     - name: plain

--- a/tests/hub-bobbycar-core-apps-naked.expected.yaml
+++ b/tests/hub-bobbycar-core-apps-naked.expected.yaml
@@ -2553,7 +2553,7 @@ spec:
             defaultMode: 420
       containers:
       - name: car-simulator
-        image: quay.io/bobbycar/car-simulator:1.1.0
+        image: quay.io/bobbycar/car-simulator:1.1.1
         imagePullPolicy: Always
         volumeMounts:
             - name: config

--- a/tests/hub-bobbycar-core-apps-normal.expected.yaml
+++ b/tests/hub-bobbycar-core-apps-normal.expected.yaml
@@ -2553,7 +2553,7 @@ spec:
             defaultMode: 420
       containers:
       - name: car-simulator
-        image: quay.io/bobbycar/car-simulator:1.1.0
+        image: quay.io/bobbycar/car-simulator:1.1.1
         imagePullPolicy: Always
         volumeMounts:
             - name: config

--- a/tests/hub-bobbycar-core-infra-naked.expected.yaml
+++ b/tests/hub-bobbycar-core-infra-naked.expected.yaml
@@ -58,7 +58,7 @@ metadata:
   namespace: test
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.1.0
     replicas: 2
     listeners:
     - name: plain

--- a/tests/hub-bobbycar-core-infra-normal.expected.yaml
+++ b/tests/hub-bobbycar-core-infra-normal.expected.yaml
@@ -58,7 +58,7 @@ metadata:
   namespace: bobbycar
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.1.0
     replicas: 2
     listeners:
     - name: plain

--- a/tests/hub-bobbycar-core-infra.expected.diff
+++ b/tests/hub-bobbycar-core-infra.expected.diff
@@ -26,7 +26,7 @@
 +  namespace: bobbycar
  spec:
    kafka:
-     version: 3.0.0
+     version: 3.1.0
 @@ -94,7 +94,7 @@
  kind: KafkaBridge
  metadata:


### PR DESCRIPTION
- Use Kafka version 3.1.0
- Use newer car-simulator tag
