### PR TITLE
Add ignoreDifferences for KafkaTopic

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -60,6 +60,12 @@ clusterGroup:
       path: charts/hub/bobbycar-core-infra
       extraHubClusterDomainFields:
         - ocpDomain
+      ignoreDifferences:
+      - kind: KafkaTopic
+        jsonPointers:
+        - /spec/config/retention.ms
+        - /spec/config/segement.bytes
+
 
     bobbycar-core-apps:
       name: bobbycar-core-apps


### PR DESCRIPTION
The problem is that the spec wants integers, which we pass, but then in
the spec/config it shows them as strings, which confuses argo greatly
and shows all KafkaTopics as OutOfSync.

I suspect this is somehow related to https://www.github.com/strimzi/strimzi-kafka-operator/issues/5869
